### PR TITLE
Allow installation of either tensorflow or tensorflow-gpu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,10 @@ setup(
     version="0.1",
     install_requires=[
         "numpy",
-        "tensorflow",
         "matplotlib",
         "pyyaml",
         "pyrouge"
-    ]
+    ],
+    extras_require={'tensorflow': ['tensorflow'],
+                    'tensorflow with gpu': ['tensorflow-gpu']},
 )


### PR DESCRIPTION
The `tensorflow` requirement in `install_requires` prevents installation of `tensorflow-gpu`. This problem is because TensorFlow has two registered Python package names, one for CPU and for GPU. I moved `tensorflow` to be in `extras_require`, so that the user can pick either. (Of course this doesn't solve all problems though.) Am open to other options.

Let me know what you think.