### PR TITLE
Don't use _asdict for Python compatibility

### DIFF
--- a/seq2seq/models/model_base.py
+++ b/seq2seq/models/model_base.py
@@ -43,7 +43,8 @@ def _flatten_dict(dict_, parent_key="", sep="."):
     if isinstance(value, collections.MutableMapping):
       items.extend(_flatten_dict(value, new_key, sep=sep).items())
     elif isinstance(value, tuple) and hasattr(value, "_asdict"):
-      items.extend(_flatten_dict(value._asdict(), new_key, sep=sep).items())
+      dict_items = collections.OrderedDict(zip(value._fields, value))
+      items.extend(_flatten_dict(dict_items, new_key, sep=sep).items())
     else:
       items.append((new_key, value))
   return dict(items)

--- a/seq2seq/models/seq2seq_model.py
+++ b/seq2seq/models/seq2seq_model.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import collections
 import tensorflow as tf
 
 from seq2seq import graph_utils
@@ -44,7 +45,9 @@ def _create_predictions(decoder_output, features, labels, losses=None):
 
   # Decoders returns output in time-major form [T, B, ...]
   # Here we transpose everything back to batch-major for the user
-  decoder_output_flat = _flatten_dict(decoder_output._asdict())
+  output_dict = collections.OrderedDict(
+      zip(decoder_output._fields, decoder_output))
+  decoder_output_flat = _flatten_dict(output_dict)
   decoder_output_flat = {
       k: _transpose_batch_time(v)
       for k, v in decoder_output_flat.items()


### PR DESCRIPTION
This should fix #43

Seems to be a bug in some Python versions: http://bugs.python.org/issue24931

TLDR; just don't use `_asdict` if you care about compatibility.