### PR TITLE
Read as unicode

### DIFF
--- a/seq2seq/training/hooks.py
+++ b/seq2seq/training/hooks.py
@@ -298,8 +298,8 @@ class PrintModelAnalysisHook(TrainingHook):
         tf.get_default_graph(), tfprof_options=opts)
 
     # Print the model analysis
-    with gfile.GFile(self._filename, "r") as file:
-      tf.logging.info(file.read().decode("utf-8"))
+    with gfile.GFile(self._filename) as file:
+      tf.logging.info(file.read())
 
 
 class VariableRestoreHook(TrainingHook):

--- a/seq2seq/training/utils.py
+++ b/seq2seq/training/utils.py
@@ -79,7 +79,7 @@ class TrainOptions(object):
         "model_params": self.model_params,
     }
 
-    with gfile.GFile(TrainOptions.path(model_dir), "w") as file:
+    with gfile.GFile(TrainOptions.path(model_dir), "wb") as file:
       file.write(json.dumps(options_dict).encode("utf-8"))
 
   @staticmethod
@@ -89,7 +89,7 @@ class TrainOptions(object):
     Args:
       model_dir: Path to the model directory.
     """
-    with gfile.GFile(TrainOptions.path(model_dir), "r") as file:
+    with gfile.GFile(TrainOptions.path(model_dir)) as file:
       options_dict = json.loads(file.read().decode("utf-8"))
     options_dict = defaultdict(None, options_dict)
 


### PR DESCRIPTION
Explicitly write in bytes and read as unicode. May be the cause of some Python unicode errors.