### PR TITLE
Configurable metrics and postprocessing

### DIFF
--- a/bin/infer.py
+++ b/bin/infer.py
@@ -16,6 +16,10 @@
 """ Generates model predictions.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 from pydoc import locate
 

--- a/bin/train.py
+++ b/bin/train.py
@@ -16,6 +16,11 @@
 """Main script to run training and evaluation of models.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os
 import tempfile
 

--- a/bin/train.py
+++ b/bin/train.py
@@ -30,7 +30,7 @@ from seq2seq import models
 from seq2seq.configurable import _maybe_load_yaml, _create_from_dict
 from seq2seq.configurable import _deep_merge_dict
 from seq2seq.data import input_pipeline
-from seq2seq.metrics.metric_specs import METRIC_SPECS_DICT
+from seq2seq.metrics import metric_specs
 from seq2seq.training import hooks
 from seq2seq.training import utils as training_utils
 
@@ -176,8 +176,10 @@ def create_experiment(output_dir):
     train_hooks.append(hook)
 
   # Create metrics
-  metric_list = FLAGS.metrics
-  eval_metrics = {m : METRIC_SPECS_DICT[m] for m in metric_list}
+  eval_metrics = {}
+  for dict_ in FLAGS.metrics:
+    metric = _create_from_dict(dict_, metric_specs)
+    eval_metrics[metric.name] = metric
 
   experiment = tf.contrib.learn.Experiment(
       estimator=estimator,

--- a/docs/nmt.md
+++ b/docs/nmt.md
@@ -159,7 +159,10 @@ export MODEL_DIR=${TMPDIR:-/tmp}/nmt_tutorial
 mkdir -p $MODEL_DIR
 
 python -m bin.train \
-  --config_paths="./example_configs/nmt_small.yml,./example_configs/train_seq2seq.yml" \
+  --config_paths="
+      ./example_configs/nmt_small.yml,
+      ./example_configs/train_seq2seq.yml,
+      ./example_configs/text_metrics_bpe.yml" \
   --model_params "
       vocab_source: $VOCAB_SOURCE
       vocab_target: $VOCAB_TARGET" \

--- a/example_configs/text_metrics_bpe.yml
+++ b/example_configs/text_metrics_bpe.yml
@@ -1,0 +1,37 @@
+default_params: &default_params
+  - separator: " "
+  - postproc_fn: "seq2seq.data.postproc.strip_bpe"
+
+metrics:
+  - class: LogPerplexityMetricSpec
+  - class: BleuMetricSpec
+    params:
+      <<: *default_params
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_1/f_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_1/r_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_1/p_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_2/f_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_2/r_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_2/p_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_l/f_score

--- a/example_configs/text_metrics_sp.yml
+++ b/example_configs/text_metrics_sp.yml
@@ -1,0 +1,37 @@
+default_params: &default_params
+  - separator: " "
+  - postproc_fn: "seq2seq.data.postproc.decode_sentencepiece"
+
+metrics:
+  - class: LogPerplexityMetricSpec
+  - class: BleuMetricSpec
+    params:
+      <<: *default_params
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_1/f_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_1/r_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_1/p_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_2/f_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_2/r_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_2/p_score
+  - class: RougeMetricSpec
+    params:
+      <<: *default_params
+      rouge_type: rouge_l/f_score

--- a/example_configs/train_seq2seq.yml
+++ b/example_configs/train_seq2seq.yml
@@ -8,13 +8,3 @@ hooks:
   - class: TokensPerSecondCounter
     params:
        every_n_steps: 100
-metrics:
-  - bleu
-  - log_perplexity
-  - rouge_1/f_score
-  - rouge_1/r_score
-  - rouge_1/p_score
-  - rouge_2/f_score
-  - rouge_2/r_score
-  - rouge_2/p_score
-  - rouge_l/f_score

--- a/seq2seq/data/input_pipeline.py
+++ b/seq2seq/data/input_pipeline.py
@@ -21,6 +21,7 @@ of (features, labels) that can be read by tf.learn estimators.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import abc
 import sys

--- a/seq2seq/data/parallel_data_provider.py
+++ b/seq2seq/data/parallel_data_provider.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import numpy as np
 

--- a/seq2seq/data/postproc.py
+++ b/seq2seq/data/postproc.py
@@ -17,6 +17,11 @@
 A collection of commonly used post-processing functions.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 def strip_bpe(text):
   """Deodes text that was processed using BPE from
   https://github.com/rsennrich/subword-nmt"""

--- a/seq2seq/data/postproc.py
+++ b/seq2seq/data/postproc.py
@@ -26,3 +26,13 @@ def decode_sentencepiece(text):
   """Decodes text that uses https://github.com/google/sentencepiece encoding.
   Assumes that pieces are separated by a space"""
   return "".join(text.split(" ")).replace("▁", " ").strip()
+
+def slice_text(text, eos_token="SEQUENCE_END", sos_token="SEQUENCE_START"):
+  """Slices text from SEQUENCE_START to SEQUENCE_END, not including
+  these special tokens.
+  """
+  eos_index = text.find(eos_token)
+  text = text[:eos_index] if eos_index > 1 else text
+  sos_index = text.find(sos_token)
+  text = text[sos_index+1:] if sos_index > 1 else text
+  return text

--- a/seq2seq/data/postproc.py
+++ b/seq2seq/data/postproc.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,11 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Collection of input-related utlities.
+
+"""
+A collection of commonly used post-processing functions.
 """
 
-from seq2seq.data import input_pipeline
-from seq2seq.data import parallel_data_provider
-from seq2seq.data import postproc
-from seq2seq.data import split_tokens_decoder
-from seq2seq.data import vocab
+def strip_bpe(text):
+  """Deodes text that was processed using BPE from
+  https://github.com/rsennrich/subword-nmt"""
+  return text.replace("@@ ", "").strip()
+
+def decode_sentencepiece(text):
+  """Decodes text that uses https://github.com/google/sentencepiece encoding.
+  Assumes that pieces are separated by a space"""
+  return "".join(text.split(" ")).replace("▁", " ").strip()

--- a/seq2seq/data/split_tokens_decoder.py
+++ b/seq2seq/data/split_tokens_decoder.py
@@ -18,6 +18,7 @@ individual tokens and the length.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import tensorflow as tf
 from tensorflow.contrib.slim.python.slim.data import data_decoder

--- a/seq2seq/decoders/attention.py
+++ b/seq2seq/decoders/attention.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import abc
 import six

--- a/seq2seq/decoders/attention_decoder.py
+++ b/seq2seq/decoders/attention_decoder.py
@@ -18,6 +18,7 @@ A basic sequence decoder that performs a softmax based on the RNN state.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from collections import namedtuple
 import tensorflow as tf

--- a/seq2seq/decoders/basic_decoder.py
+++ b/seq2seq/decoders/basic_decoder.py
@@ -18,6 +18,7 @@ A basic sequence decoder that performs a softmax based on the RNN state.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import tensorflow as tf
 from seq2seq.decoders.rnn_decoder import RNNDecoder, DecoderOutput

--- a/seq2seq/decoders/beam_search_decoder.py
+++ b/seq2seq/decoders/beam_search_decoder.py
@@ -18,6 +18,7 @@ training.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from collections import namedtuple
 

--- a/seq2seq/decoders/rnn_decoder.py
+++ b/seq2seq/decoders/rnn_decoder.py
@@ -18,6 +18,7 @@ Base class for sequence decoders.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import abc
 from collections import namedtuple

--- a/seq2seq/metrics/metric_specs.py
+++ b/seq2seq/metrics/metric_specs.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from pydoc import locate
 import abc

--- a/seq2seq/metrics/metric_specs.py
+++ b/seq2seq/metrics/metric_specs.py
@@ -19,7 +19,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from pydoc import locate
 import abc
+
 import numpy as np
 import six
 
@@ -27,6 +29,7 @@ import tensorflow as tf
 from tensorflow.contrib import metrics
 from tensorflow.contrib.learn import MetricSpec
 
+from seq2seq.configurable import Configurable
 from seq2seq.metrics import rouge
 from seq2seq.metrics import bleu
 
@@ -55,34 +58,56 @@ def accumulate_strings(values, name="strings"):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class TextMetricSpec(MetricSpec):
+class TextMetricSpec(Configurable, MetricSpec):
   """Abstract class for text-based metrics calculated based on
   hypotheses and references. Subclasses must implement `metric_fn`.
 
   Args:
     name: A name for the metric
-    separator: A seperator used to join predicted tokens. Default to space.
+    separator: A separator used to join predicted tokens. Default to space.
     eos_token: A string token used to find the end of a sequence. Hypotheses
       and references will be slcied until this token is found.
   """
 
-  def __init__(self, name, separator=" ", eos_token="SEQUENCE_END"):
+  def __init__(self, params, name):
     # We don't call the super constructor on purpose
     #pylint: disable=W0231
     """Initializer"""
-    self.name = name
-    self.separator = separator
-    self.eos_token = eos_token
+    Configurable.__init__(self, params, tf.contrib.learn.ModeKeys.EVAL)
+    self._name = name
+    self._eos_token = self.params["eos_token"]
+    self._separator = self.params["separator"]
+    self._postproc_fn = None
+    if self.params["postproc_fn"]:
+      self._postproc_fn = locate(self.params["postproc_fn"])
+      if self._postproc_fn is None:
+        raise ValueError("postproc_fn not found: {}".format(
+            self.params["postproc_fn"]))
+
+  @property
+  def name(self):
+    """Name of the metric"""
+    return self._name
+
+  @staticmethod
+  def default_params():
+    return {
+        "eos_token": "SEQUENCE_END",
+        "separator": " ",
+        "postproc_fn": "",
+    }
 
   def create_metric_ops(self, _inputs, labels, predictions):
     """Creates (value, update_op) tensors
     """
-    with tf.variable_scope(self.name):
+    with tf.variable_scope(self._name):
+
       # Join tokens into single strings
       predictions_flat = tf.reduce_join(
-          predictions["predicted_tokens"], 1, separator=self.separator)
+          predictions["predicted_tokens"], 1, separator=self._separator)
+      # We slice from 1: to not include the SEQUENCE_START token
       labels_flat = tf.reduce_join(
-          labels["target_tokens"], 1, separator=self.separator)
+          labels["target_tokens"][:,1:], 1, separator=self._separator)
 
       sources_value, sources_update = accumulate_strings(
           values=predictions_flat, name="sources")
@@ -112,22 +137,20 @@ class TextMetricSpec(MetricSpec):
 
     # Slice all hypotheses and references up to EOS
     sliced_hypotheses = [
-        x.split(self.eos_token.encode("utf-8"))[0].strip() for x in hypotheses
+        x.split(self._eos_token.encode("utf-8"))[0].strip() for x in hypotheses
     ]
     sliced_references = [
-        x.split(self.eos_token.encode("utf-8"))[0].strip() for x in references
+        x.split(self._eos_token.encode("utf-8"))[0].strip() for x in references
     ]
-
-    # Strip special "@@ " tokens used for BPE
-    # See https://github.com/rsennrich/subword-nmt
-    # We hope this is rare enough that it will not have any adverse effects
-    # on predicitons that do not use BPE
-    sliced_hypotheses = [_.replace(b"@@ ", b"") for _ in sliced_hypotheses]
-    sliced_references = [_.replace(b"@@ ", b"") for _ in sliced_references]
 
     # Convert back to unicode object
     sliced_hypotheses = [_.decode("utf-8") for _ in sliced_hypotheses]
     sliced_references = [_.decode("utf-8") for _ in sliced_references]
+
+    # Apply postprocessing function
+    if self._postproc_fn:
+      sliced_hypotheses = [self._postproc_fn(_) for _ in sliced_hypotheses]
+      sliced_references = [self._postproc_fn(_) for _ in sliced_references]
 
     return self.metric_fn(sliced_hypotheses, sliced_references)
 
@@ -150,8 +173,8 @@ class BleuMetricSpec(TextMetricSpec):
   """Calculates BLEU score using the Moses multi-bleu.perl script.
   """
 
-  def __init__(self, separator=" ", eos_token="SEQUENCE_END"):
-    super(BleuMetricSpec, self).__init__("bleu_metric", separator, eos_token)
+  def __init__(self, params):
+    super(BleuMetricSpec, self).__init__(params, "bleu")
 
   def metric_fn(self, hypotheses, references):
     return bleu.moses_multi_bleu(hypotheses, references, lowercase=False)
@@ -161,24 +184,44 @@ class RougeMetricSpec(TextMetricSpec):
   """Calculates BLEU score using the Moses multi-bleu.perl script.
   """
 
-  def __init__(self, metric_name, **kwargs):
-    super(RougeMetricSpec, self).__init__(metric_name, **kwargs)
-    self.metric_name = metric_name
+  def __init__(self, params, **kwargs):
+    if not params["rouge_type"]:
+      raise ValueError("You must provide a rouge_type for ROUGE")
+    super(RougeMetricSpec, self).__init__(
+        params, params["rouge_type"], **kwargs)
+    self._rouge_type = self.params["rouge_type"]
+
+  @staticmethod
+  def default_params():
+    params = TextMetricSpec.default_params()
+    params.update({
+        "rouge_type": "",
+    })
+    return params
 
   def metric_fn(self, hypotheses, references):
     if not hypotheses or not references:
       return np.float32(0.0)
-    return np.float32(rouge.rouge(hypotheses, references)[self.metric_name])
+    return np.float32(rouge.rouge(hypotheses, references)[self._rouge_type])
 
 
-class LogPerplexityMetricSpec(MetricSpec):
+class LogPerplexityMetricSpec(MetricSpec, Configurable):
   """A MetricSpec to calculate straming log perplexity"""
 
-  def __init__(self):
+  def __init__(self, params):
     """Initializer"""
     # We don't call the super constructor on purpose
     #pylint: disable=W0231
-    pass
+    Configurable.__init__(self, params, tf.contrib.learn.ModeKeys.EVAL)
+
+  @staticmethod
+  def default_params():
+    return {}
+
+  @property
+  def name(self):
+    """Name of the metric"""
+    return "log_perplexity"
 
   def create_metric_ops(self, _inputs, labels, predictions):
     """Creates the metric op"""
@@ -186,16 +229,3 @@ class LogPerplexityMetricSpec(MetricSpec):
         lengths=tf.to_int32(labels["target_len"] - 1),
         maxlen=tf.to_int32(tf.shape(predictions["losses"])[1]))
     return metrics.streaming_mean(predictions["losses"], loss_mask)
-
-
-METRIC_SPECS_DICT = {
-    "bleu": BleuMetricSpec(),
-    "log_perplexity": LogPerplexityMetricSpec(),
-    "rouge_1/f_score": RougeMetricSpec("rouge_1/f_score"),
-    "rouge_1/r_score": RougeMetricSpec("rouge_1/r_score"),
-    "rouge_1/p_score": RougeMetricSpec("rouge_1/p_score"),
-    "rouge_2/f_score": RougeMetricSpec("rouge_2/f_score"),
-    "rouge_2/r_score": RougeMetricSpec("rouge_2/r_score"),
-    "rouge_2/p_score": RougeMetricSpec("rouge_2/p_score"),
-    "rouge_l/f_score": RougeMetricSpec("rouge_l/f_score")
-}

--- a/seq2seq/metrics/rouge.py
+++ b/seq2seq/metrics/rouge.py
@@ -19,7 +19,9 @@ https://github.com/miso-belica/sumy/blob/dev/sumy/evaluation/rouge.py.
 """
 
 from __future__ import absolute_import
-from __future__ import division, print_function, unicode_literals
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 
 import itertools
 import numpy as np

--- a/seq2seq/models/attention_seq2seq.py
+++ b/seq2seq/models/attention_seq2seq.py
@@ -18,6 +18,7 @@ Sequence to Sequence model with attention
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from pydoc import locate
 

--- a/seq2seq/models/basic_seq2seq.py
+++ b/seq2seq/models/basic_seq2seq.py
@@ -18,6 +18,7 @@ Definition of a basic seq2seq model
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from pydoc import locate
 import tensorflow as tf

--- a/seq2seq/models/bridges.py
+++ b/seq2seq/models/bridges.py
@@ -18,6 +18,7 @@ how encoder information are passed to the decoder.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import abc
 from pydoc import locate

--- a/seq2seq/models/image2seq.py
+++ b/seq2seq/models/image2seq.py
@@ -18,6 +18,7 @@ Definition of a basic seq2seq model
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import tensorflow as tf
 

--- a/seq2seq/models/model_base.py
+++ b/seq2seq/models/model_base.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import collections
 import tensorflow as tf

--- a/seq2seq/models/seq2seq_model.py
+++ b/seq2seq/models/seq2seq_model.py
@@ -16,6 +16,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import collections
 

--- a/seq2seq/models/seq2seq_model.py
+++ b/seq2seq/models/seq2seq_model.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+
 import tensorflow as tf
 
 from seq2seq import graph_utils
@@ -28,41 +29,6 @@ from seq2seq.graph_utils import templatemethod
 from seq2seq.decoders.beam_search_decoder import BeamSearchDecoder
 from seq2seq.inference import beam_search
 from seq2seq.models.model_base import ModelBase, _flatten_dict
-
-
-def _create_predictions(decoder_output, features, labels, losses=None):
-  """Creates the dictionary of predictions that is returned by the model.
-  """
-  predictions = {}
-
-  # Add features and, if available, labels to predictions
-  predictions.update(_flatten_dict({"features": features}))
-  if labels is not None:
-    predictions.update(_flatten_dict({"labels": labels}))
-
-  if losses is not None:
-    predictions["losses"] = _transpose_batch_time(losses)
-
-  # Decoders returns output in time-major form [T, B, ...]
-  # Here we transpose everything back to batch-major for the user
-  output_dict = collections.OrderedDict(
-      zip(decoder_output._fields, decoder_output))
-  decoder_output_flat = _flatten_dict(output_dict)
-  decoder_output_flat = {
-      k: _transpose_batch_time(v)
-      for k, v in decoder_output_flat.items()
-  }
-  predictions.update(decoder_output_flat)
-
-  # If we predict the ids also map them back into the vocab
-  if "predicted_ids" in predictions.keys():
-    vocab_tables = graph_utils.get_dict_from_collection("vocab_tables")
-    target_id_to_vocab = vocab_tables["target_id_to_vocab"]
-    predicted_tokens = target_id_to_vocab.lookup(
-        tf.to_int64(predictions["predicted_ids"]))
-    predictions["predicted_tokens"] = predicted_tokens
-
-  return predictions
 
 
 class Seq2SeqModel(ModelBase):
@@ -96,6 +62,41 @@ class Seq2SeqModel(ModelBase):
         "vocab_target": "",
     })
     return params
+
+  def _create_predictions(self, decoder_output, features, labels, losses=None):
+    """Creates the dictionary of predictions that is returned by the model.
+    """
+    predictions = {}
+
+    # Add features and, if available, labels to predictions
+    predictions.update(_flatten_dict({"features": features}))
+    if labels is not None:
+      predictions.update(_flatten_dict({"labels": labels}))
+
+    if losses is not None:
+      predictions["losses"] = _transpose_batch_time(losses)
+
+    # Decoders returns output in time-major form [T, B, ...]
+    # Here we transpose everything back to batch-major for the user
+    output_dict = collections.OrderedDict(
+        zip(decoder_output._fields, decoder_output))
+    decoder_output_flat = _flatten_dict(output_dict)
+    decoder_output_flat = {
+        k: _transpose_batch_time(v)
+        for k, v in decoder_output_flat.items()
+    }
+    predictions.update(decoder_output_flat)
+
+    # If we predict the ids also map them back into the vocab and process them
+    if "predicted_ids" in predictions.keys():
+      vocab_tables = graph_utils.get_dict_from_collection("vocab_tables")
+      target_id_to_vocab = vocab_tables["target_id_to_vocab"]
+      predicted_tokens = target_id_to_vocab.lookup(
+          tf.to_int64(predictions["predicted_ids"]))
+      # Raw predicted tokens
+      predictions["predicted_tokens"] = predicted_tokens
+
+    return predictions
 
   def batch_size(self, features, labels):
     """Returns the batch size of the curren batch based on the passed
@@ -164,9 +165,6 @@ class Seq2SeqModel(ModelBase):
 
     - Creates vocabulary lookup tables for source and target vocab
     - Converts tokens into vocabulary ids
-    - Appends a special "SEQUENCE_END" token to the source
-    - Prepends a special "SEQUENCE_START" token to the target
-    - Appends a special "SEQUENCE_END" token to the target
     """
 
     # Create vocabulary lookup for source
@@ -263,7 +261,7 @@ class Seq2SeqModel(ModelBase):
     decoder_output, _, = self.decode(encoder_output, features, labels)
 
     if self.mode == tf.contrib.learn.ModeKeys.INFER:
-      predictions = _create_predictions(
+      predictions = self._create_predictions(
           decoder_output=decoder_output, features=features, labels=labels)
       loss = None
       train_op = None
@@ -274,7 +272,7 @@ class Seq2SeqModel(ModelBase):
       if self.mode == tf.contrib.learn.ModeKeys.TRAIN:
         train_op = self._build_train_op(loss)
 
-      predictions = _create_predictions(
+      predictions = self._create_predictions(
           decoder_output=decoder_output,
           features=features,
           labels=labels,

--- a/seq2seq/tasks/decode_text.py
+++ b/seq2seq/tasks/decode_text.py
@@ -15,6 +15,11 @@
 Task where both the input and output sequence are plain text.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import functools
 from pydoc import locate
 

--- a/seq2seq/tasks/dump_attention.py
+++ b/seq2seq/tasks/dump_attention.py
@@ -15,6 +15,11 @@
 Task where both the input and output sequence are plain text.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import os
 
 import numpy as np

--- a/seq2seq/tasks/dump_beams.py
+++ b/seq2seq/tasks/dump_beams.py
@@ -15,6 +15,11 @@
 Task where both the input and output sequence are plain text.
 """
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import numpy as np
 
 import tensorflow as tf

--- a/seq2seq/tasks/inference_task.py
+++ b/seq2seq/tasks/inference_task.py
@@ -18,6 +18,7 @@ Abstract base class for inference tasks.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import abc
 

--- a/seq2seq/test/attention_test.py
+++ b/seq2seq/test/attention_test.py
@@ -18,6 +18,7 @@ Unit tests for attention functions.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import tensorflow as tf
 import numpy as np

--- a/seq2seq/test/beam_search_test.py
+++ b/seq2seq/test/beam_search_test.py
@@ -18,6 +18,7 @@ Tests for Beam Search and related functions.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import tensorflow as tf
 import numpy as np

--- a/seq2seq/test/bridges_test.py
+++ b/seq2seq/test/bridges_test.py
@@ -18,6 +18,7 @@ Tests for Encoder-Decoder bridges.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from collections import namedtuple
 import numpy as np

--- a/seq2seq/test/decoder_test.py
+++ b/seq2seq/test/decoder_test.py
@@ -18,6 +18,7 @@ Test Cases for decoders.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import tensorflow as tf
 import numpy as np

--- a/seq2seq/test/losses_test.py
+++ b/seq2seq/test/losses_test.py
@@ -18,6 +18,7 @@ Unit tests for loss-related operations.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 from seq2seq import losses as seq2seq_losses
 import tensorflow as tf

--- a/seq2seq/test/metrics_test.py
+++ b/seq2seq/test/metrics_test.py
@@ -102,7 +102,7 @@ class TestBleuMetricSpec(TestTextMetricSpec):
   """Tests the `BleuMetricSpec`"""
 
   def test_bleu(self):
-    metric_spec = BleuMetricSpec()
+    metric_spec = BleuMetricSpec({})
     return self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],
@@ -114,7 +114,7 @@ class TestRougeMetricSpec(TestTextMetricSpec):
   """Tests the `RougeMetricSpec`"""
 
   def test_rouge_1_f_score(self):
-    metric_spec = RougeMetricSpec("rouge_1/f_score")
+    metric_spec = RougeMetricSpec({}, "rouge_1/f_score")
     return self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],
@@ -122,7 +122,7 @@ class TestRougeMetricSpec(TestTextMetricSpec):
         expected_scores=[1.0, 0.954])
 
   def test_rouge_2_f_score(self):
-    metric_spec = RougeMetricSpec("rouge_2/f_score")
+    metric_spec = RougeMetricSpec({}, "rouge_2/f_score")
     return self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],
@@ -130,7 +130,7 @@ class TestRougeMetricSpec(TestTextMetricSpec):
         expected_scores=[1.0, 0.8])
 
   def test_rouge_l_f_score(self):
-    metric_spec = RougeMetricSpec("rouge_l/f_score")
+    metric_spec = RougeMetricSpec({}, "rouge_l/f_score")
     return self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],

--- a/seq2seq/test/metrics_test.py
+++ b/seq2seq/test/metrics_test.py
@@ -114,7 +114,7 @@ class TestRougeMetricSpec(TestTextMetricSpec):
   """Tests the `RougeMetricSpec`"""
 
   def test_rouge_1_f_score(self):
-    metric_spec = RougeMetricSpec({}, "rouge_1/f_score")
+    metric_spec = RougeMetricSpec({"rouge_type":  "rouge_1/f_score"})
     return self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],
@@ -122,7 +122,7 @@ class TestRougeMetricSpec(TestTextMetricSpec):
         expected_scores=[1.0, 0.954])
 
   def test_rouge_2_f_score(self):
-    metric_spec = RougeMetricSpec({}, "rouge_2/f_score")
+    metric_spec = RougeMetricSpec({"rouge_type":  "rouge_2/f_score"})
     return self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],
@@ -130,7 +130,7 @@ class TestRougeMetricSpec(TestTextMetricSpec):
         expected_scores=[1.0, 0.8])
 
   def test_rouge_l_f_score(self):
-    metric_spec = RougeMetricSpec({}, "rouge_l/f_score")
+    metric_spec = RougeMetricSpec({"rouge_type":  "rouge_l/f_score"})
     return self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],

--- a/seq2seq/test/pipeline_test.py
+++ b/seq2seq/test/pipeline_test.py
@@ -79,8 +79,13 @@ class PipelineTest(tf.test.TestCase):
 
     # Set training flags
     tf.app.flags.FLAGS.output_dir = self.output_dir
-    tf.app.flags.FLAGS.metrics = yaml.dump(
-        ["log_perplexity", "bleu", "rouge_1/f_score", "rouge_l/f_score"])
+    tf.app.flags.FLAGS.metrics = """
+      - class: LogPerplexityMetricSpec
+      - class: BleuMetricSpec
+      - class: RougeMetricSpec
+        params:
+          rouge_type: rouge_1/f_score
+    """
     tf.app.flags.FLAGS.model = "AttentionSeq2Seq"
     tf.app.flags.FLAGS.model_params = """
     attention.params:
@@ -213,6 +218,8 @@ class PipelineTest(tf.test.TestCase):
     """
     tf.app.flags.FLAGS.tasks = """
     - class: DecodeText
+      params:
+        postproc_fn: seq2seq.data.postproc.decode_sentencepiece
     - class: DumpBeams
       params:
         file: {}

--- a/seq2seq/test/pooling_encoder_test.py
+++ b/seq2seq/test/pooling_encoder_test.py
@@ -18,6 +18,7 @@ Test Cases for PoolingEncoder.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import tensorflow as tf
 import numpy as np

--- a/seq2seq/test/rnn_encoder_test.py
+++ b/seq2seq/test/rnn_encoder_test.py
@@ -18,6 +18,7 @@ Test Cases for RNN encoders.
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import tensorflow as tf
 import numpy as np

--- a/seq2seq/training/hooks.py
+++ b/seq2seq/training/hooks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +18,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import abc
 import os


### PR DESCRIPTION
Allows metrics to be configured with text seperators and post-processing functions. This will make them work with data that is pre-processed different, e.g. character-level models google/sentencepiece. 

- Also Fixes #39
- Also fixes #32

Fixes #70 