### PR TITLE
Handle ROUGE recall edge case

### DIFF
--- a/seq2seq/metrics/rouge.py
+++ b/seq2seq/metrics/rouge.py
@@ -171,7 +171,12 @@ def rouge_n(evaluated_sentences, reference_sentences, n=2):
     precision = 0.0
   else:
     precision = overlapping_count / evaluated_count
-  recall = overlapping_count / reference_count
+
+  if reference_count == 0:
+    recall = 0.0
+  else:
+    recall = overlapping_count / reference_count
+
   f1_score = 2.0 * ((precision * recall) / (precision + recall + 1e-8))
 
   # return overlapping_count / reference_count

--- a/seq2seq/test/metrics_test.py
+++ b/seq2seq/test/metrics_test.py
@@ -54,6 +54,13 @@ class TestMosesBleu(tf.test.TestCase):
         lowercase=False,
         expected_bleu=46.51)
 
+  def test_empty(self):
+    self._test_multi_bleu(
+        hypotheses=np.array([]),
+        references=np.array([]),
+        lowercase=False,
+        expected_bleu=0.00)
+
   def test_multi_bleu_lowercase(self):
     self._test_multi_bleu(
         hypotheses=np.array([
@@ -115,27 +122,65 @@ class TestRougeMetricSpec(TestTextMetricSpec):
 
   def test_rouge_1_f_score(self):
     metric_spec = RougeMetricSpec({"rouge_type":  "rouge_1/f_score"})
-    return self._test_metric_spec(
+    self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],
         refs=["A B C D E F", "A B A D E F"],
         expected_scores=[1.0, 0.954])
 
+    self._test_metric_spec(
+        metric_spec=metric_spec,
+        hyps=[],
+        refs=[],
+        expected_scores=[0.0])
+
+    self._test_metric_spec(
+        metric_spec=metric_spec,
+        hyps=["A"],
+        refs=["B"],
+        expected_scores=[0.0])
+
+
   def test_rouge_2_f_score(self):
     metric_spec = RougeMetricSpec({"rouge_type":  "rouge_2/f_score"})
-    return self._test_metric_spec(
+    self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],
         refs=["A B C D E F", "A B A D E F"],
         expected_scores=[1.0, 0.8])
 
+    self._test_metric_spec(
+        metric_spec=metric_spec,
+        hyps=[],
+        refs=[],
+        expected_scores=[0.0])
+
+    self._test_metric_spec(
+        metric_spec=metric_spec,
+        hyps=["A"],
+        refs=["B"],
+        expected_scores=[0.0])
+
   def test_rouge_l_f_score(self):
     metric_spec = RougeMetricSpec({"rouge_type":  "rouge_l/f_score"})
-    return self._test_metric_spec(
+
+    self._test_metric_spec(
         metric_spec=metric_spec,
         hyps=["A B C D E F", "A B C D E F"],
         refs=["A B C D E F", "A B A D E F"],
         expected_scores=[1.0, 0.916])
+
+    self._test_metric_spec(
+        metric_spec=metric_spec,
+        hyps=[],
+        refs=[],
+        expected_scores=[0.0])
+
+    self._test_metric_spec(
+        metric_spec=metric_spec,
+        hyps=["A"],
+        refs=["B"],
+        expected_scores=[0.0])
 
 
 class TestRougeMetric(tf.test.TestCase):


### PR DESCRIPTION
Returns 0.0 recall if there are no n-gram overlaps. Also added improved tests for this case. Fixes #77.