### PR TITLE
Fix unicode print error

### DIFF
--- a/seq2seq/tasks/decode_text.py
+++ b/seq2seq/tasks/decode_text.py
@@ -185,4 +185,4 @@ class DecodeText(InferenceTask):
 
       sent = sent.strip()
 
-      print(sent)
+      print(sent.encode('utf8'))


### PR DESCRIPTION
Convert unicode string to byte string before printing.