### PR TITLE
add case for tab character in vocabulary

### DIFF
--- a/seq2seq/data/vocab.py
+++ b/seq2seq/data/vocab.py
@@ -84,7 +84,10 @@ def create_vocabulary_lookup_table(filename, default_value=None):
 
   has_counts = len(vocab[0].split("\t")) == 2
   if has_counts:
-    vocab, counts = zip(*[_.split("\t") for _ in vocab])
+    pairs = [["\t", line.split("\t")[-1]]
+              if line.startswith("\t\t") else line.split("\t")
+              for line in vocab]
+    vocab, counts = zip(*pairs)
     counts = [float(_) for _ in counts]
     vocab = list(vocab)
   else:

--- a/seq2seq/test/hooks_test.py
+++ b/seq2seq/test/hooks_test.py
@@ -47,7 +47,7 @@ class TestPrintModelAnalysisHook(tf.test.TestCase):
     with gfile.GFile(os.path.join(model_dir, "model_analysis.txt")) as file:
       file_contents = file.read().strip()
 
-    self.assertEqual(file_contents.decode(), "_TFProfRoot (--/16.38k params)\n"
+    self.assertEqual(file_contents, "_TFProfRoot (--/16.38k params)\n"
                      "  weigths (128x128, 16.38k/16.38k params)")
     outfile.close()
 


### PR DESCRIPTION
The vocabulary sources file is tab separated, so a special case is needed for
when the tab character is part of the vocabulary in character-level models.