### PR TITLE
Fixes to work with TensorFlow 1.2

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -292,7 +292,7 @@ generated-members=set_shape,np.float32
 # List of decorators that produce context managers, such as
 # contextlib.contextmanager. Add to this list to register other decorators that
 # produce valid context managers.
-contextmanager-decorators=contextlib.contextmanager
+contextmanager-decorators=contextlib.contextmanager,tensorflow.python.util.tf_contextlib.contextmanager
 
 
 [VARIABLES]

--- a/seq2seq/contrib/seq2seq/helper.py
+++ b/seq2seq/contrib/seq2seq/helper.py
@@ -32,8 +32,13 @@ import abc
 
 import six
 
-from tensorflow.contrib.distributions.python.ops import bernoulli
-from tensorflow.contrib.distributions.python.ops import categorical
+try:
+  from tensorflow.python.ops.distributions import bernoulli
+  from tensorflow.python.ops.distributions import categorical
+except:
+  # Backwards compatibility with TensorFlow prior to 1.2.
+  from tensorflow.contrib.distributions.python.ops import bernoulli
+  from tensorflow.contrib.distributions.python.ops import categorical
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.layers import base as layers_base

--- a/seq2seq/data/input_pipeline.py
+++ b/seq2seq/data/input_pipeline.py
@@ -29,7 +29,9 @@ import sys
 import six
 
 import tensorflow as tf
+# pylint: disable=no-name-in-module
 from tensorflow.contrib.slim.python.slim.data import tfexample_decoder
+# pylint: enable=no-name-in-module
 
 from seq2seq.configurable import Configurable
 from seq2seq.data import split_tokens_decoder, parallel_data_provider

--- a/seq2seq/data/parallel_data_provider.py
+++ b/seq2seq/data/parallel_data_provider.py
@@ -22,8 +22,10 @@ from __future__ import unicode_literals
 import numpy as np
 
 import tensorflow as tf
+# pylint: disable=no-name-in-module
 from tensorflow.contrib.slim.python.slim.data import data_provider
 from tensorflow.contrib.slim.python.slim.data import parallel_reader
+# pylint: enable=no-name-in-module
 
 from seq2seq.data import split_tokens_decoder
 

--- a/seq2seq/data/sequence_example_decoder.py
+++ b/seq2seq/data/sequence_example_decoder.py
@@ -14,7 +14,9 @@
 """A decoder for tf.SequenceExample"""
 
 import tensorflow as tf
+# pylint: disable=no-name-in-module
 from tensorflow.contrib.slim.python.slim.data import data_decoder
+# pylint: enable=no-name-in-module
 
 
 class TFSEquenceExampleDecoder(data_decoder.DataDecoder):

--- a/seq2seq/data/split_tokens_decoder.py
+++ b/seq2seq/data/split_tokens_decoder.py
@@ -21,7 +21,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import tensorflow as tf
+# pylint: disable=no-name-in-module
 from tensorflow.contrib.slim.python.slim.data import data_decoder
+# pylint: enable=no-name-in-module
 
 
 class SplitTokensDecoder(data_decoder.DataDecoder):

--- a/seq2seq/encoders/image_encoder.py
+++ b/seq2seq/encoders/image_encoder.py
@@ -20,8 +20,10 @@ from __future__ import division
 from __future__ import print_function
 
 import tensorflow as tf
+# pylint: disable=no-name-in-module
 from tensorflow.contrib.slim.python.slim.nets.inception_v3 \
   import inception_v3_base
+# pylint: enable=no-name-in-module
 
 from seq2seq.encoders.encoder import Encoder, EncoderOutput
 

--- a/seq2seq/encoders/rnn_encoder.py
+++ b/seq2seq/encoders/rnn_encoder.py
@@ -21,7 +21,6 @@ from __future__ import print_function
 
 import copy
 import tensorflow as tf
-from tensorflow.contrib.rnn.python.ops import rnn
 
 from seq2seq.encoders.encoder import Encoder, EncoderOutput
 from seq2seq.training import utils as training_utils
@@ -186,7 +185,7 @@ class StackBidirectionalRNNEncoder(Encoder):
     cells_fw = _unpack_cell(cell_fw)
     cells_bw = _unpack_cell(cell_bw)
 
-    result = rnn.stack_bidirectional_dynamic_rnn(
+    result = tf.contrib.rnn.stack_bidirectional_dynamic_rnn(
         cells_fw=cells_fw,
         cells_bw=cells_bw,
         inputs=inputs,

--- a/seq2seq/metrics/metric_specs.py
+++ b/seq2seq/metrics/metric_specs.py
@@ -28,7 +28,9 @@ import six
 
 import tensorflow as tf
 from tensorflow.contrib import metrics
+# pylint: disable=no-name-in-module
 from tensorflow.contrib.learn import MetricSpec
+# pylint: enable=no-name-in-module
 
 from seq2seq.data import postproc
 from seq2seq.configurable import Configurable

--- a/seq2seq/test/hooks_test.py
+++ b/seq2seq/test/hooks_test.py
@@ -49,10 +49,10 @@ class TestPrintModelAnalysisHook(tf.test.TestCase):
       file_contents = file.read().strip()
 
     if LooseVersion(tf.VERSION) < LooseVersion("1.2.0"):
-      self.assertEqual(file_contents.decode(), "_TFProfRoot (--/16.38k params)\n"
+      self.assertEqual(tf.compat.as_text(file_contents), "_TFProfRoot (--/16.38k params)\n"
                        "  weights (128x128, 16.38k/16.38k params)")
     else:
-      self.assertEqual(file_contents.decode(), "node name | # parameters\n"
+      self.assertEqual(tf.compat.as_text(file_contents), "node name | # parameters\n"
                        "_TFProfRoot (--/16.38k params)\n"
                        "  weights (128x128, 16.38k/16.38k params)")
 

--- a/seq2seq/test/hooks_test.py
+++ b/seq2seq/test/hooks_test.py
@@ -39,7 +39,7 @@ class TestPrintModelAnalysisHook(tf.test.TestCase):
   def test_begin(self):
     model_dir = tempfile.mkdtemp()
     outfile = tempfile.NamedTemporaryFile()
-    tf.get_variable("weigths", [128, 128])
+    tf.get_variable("weights", [128, 128])
     hook = hooks.PrintModelAnalysisHook(
         params={}, model_dir=model_dir, run_config=tf.contrib.learn.RunConfig())
     hook.begin()
@@ -125,7 +125,7 @@ class TestMetadataCaptureHook(tf.test.TestCase):
   def test_capture(self):
     global_step = tf.contrib.framework.get_or_create_global_step()
     # Some test computation
-    some_weights = tf.get_variable("weigths", [2, 128])
+    some_weights = tf.get_variable("weights", [2, 128])
     computation = tf.nn.softmax(some_weights)
 
     hook = hooks.MetadataCaptureHook(

--- a/seq2seq/test/hooks_test.py
+++ b/seq2seq/test/hooks_test.py
@@ -24,7 +24,6 @@ import os
 import tempfile
 import shutil
 import time
-from distutils.version import LooseVersion
 
 import tensorflow as tf
 from tensorflow.python.training import monitored_session  # pylint: disable=E0611
@@ -48,13 +47,13 @@ class TestPrintModelAnalysisHook(tf.test.TestCase):
     with gfile.GFile(os.path.join(model_dir, "model_analysis.txt")) as file:
       file_contents = file.read().strip()
 
-    if LooseVersion(tf.VERSION) < LooseVersion("1.2.0"):
-      self.assertEqual(tf.compat.as_text(file_contents), "_TFProfRoot (--/16.38k params)\n"
-                       "  weights (128x128, 16.38k/16.38k params)")
-    else:
-      self.assertEqual(tf.compat.as_text(file_contents), "node name | # parameters\n"
-                       "_TFProfRoot (--/16.38k params)\n"
-                       "  weights (128x128, 16.38k/16.38k params)")
+    lines = tf.compat.as_text(file_contents).split("\n")
+    if len(lines) == 3:
+      # TensorFlow v1.2 includes an extra header line
+      self.assertEqual(lines[0], "node name | # parameters")
+
+    self.assertEqual(lines[-2], "_TFProfRoot (--/16.38k params)")
+    self.assertEqual(lines[-1], "  weights (128x128, 16.38k/16.38k params)")
 
     outfile.close()
 

--- a/seq2seq/test/hooks_test.py
+++ b/seq2seq/test/hooks_test.py
@@ -24,6 +24,7 @@ import os
 import tempfile
 import shutil
 import time
+from distutils.version import LooseVersion
 
 import tensorflow as tf
 from tensorflow.python.training import monitored_session  # pylint: disable=E0611
@@ -47,8 +48,14 @@ class TestPrintModelAnalysisHook(tf.test.TestCase):
     with gfile.GFile(os.path.join(model_dir, "model_analysis.txt")) as file:
       file_contents = file.read().strip()
 
-    self.assertEqual(file_contents.decode(), "_TFProfRoot (--/16.38k params)\n"
-                     "  weigths (128x128, 16.38k/16.38k params)")
+    if LooseVersion(tf.VERSION) < LooseVersion("1.2.0"):
+      self.assertEqual(file_contents.decode(), "_TFProfRoot (--/16.38k params)\n"
+                       "  weights (128x128, 16.38k/16.38k params)")
+    else:
+      self.assertEqual(file_contents.decode(), "node name | # parameters\n"
+                       "_TFProfRoot (--/16.38k params)\n"
+                       "  weights (128x128, 16.38k/16.38k params)")
+
     outfile.close()
 
 


### PR DESCRIPTION
Some minor, albeit ugly, fixes to support TF1.2 - tested against 1.2.0-rc1.

I've checked these don't break the tests for the current TF1.1 version.