### PR TITLE
add a checked parameter type in _maybe_load_yaml()

### DIFF
--- a/seq2seq/configurable.py
+++ b/seq2seq/configurable.py
@@ -60,10 +60,10 @@ def _maybe_load_yaml(item):
   """
   if isinstance(item, six.string_types):
     return yaml.load(item)
-  elif isinstance(item, dict):
+  elif isinstance(item, dict) or isinstance(item, list):
     return item
   else:
-    raise ValueError("Got {}, expected YAML string or dict", type(item))
+    raise ValueError("Got {}, expected YAML string or dict or list of dicts", type(item))
 
 
 def _deep_merge_dict(dict_x, dict_y, path=None):


### PR DESCRIPTION
In the examples of the official manual, there are some examples whose parameters maybe passed in as a list of dicts. 
e.g. the "tasks" parameter in the following example, 
In https://google.github.io/seq2seq/nmt/#decoding-with-beam-search,
```
python -m bin.infer \
  --tasks "
    - class: DecodeText
    - class: DumpBeams
      params:
        file: ${PRED_DIR}/beams.npz" \
  --model_dir $MODEL_DIR \
  --model_params "
    inference.beam_search.beam_width: 5" \
  --input_pipeline "
    class: ParallelTextInputPipeline
    params:
      source_files:
        - $DEV_SOURCES" \
  > ${PRED_DIR}/predictions.txt
```